### PR TITLE
Create tags automatically when invoked

### DIFF
--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -148,8 +148,9 @@ export function tag(id: symbol | string): OptionsFn {
         // apply the tag
         let tag = getTag(schedule, id);
 
+        // create the tag if it doesn't exist
         if (!tag) {
-            throw new Error(`Could not find tag with id ${String(id)}`);
+            tag = createTag(schedule, id);
         }
 
         dag.addEdge(tag.before, runnable);

--- a/packages/scheduler/src/tests/scheduler.test.ts
+++ b/packages/scheduler/src/tests/scheduler.test.ts
@@ -1,14 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import {
-    add,
-    after,
-    before,
-    id,
-    create,
-    createTag,
-    run,
-    tag,
-} from '../scheduler';
+import { add, after, before, id, create, run, tag } from '../scheduler';
 
 describe('Scheduler', () => {
     let order: string[] = [];
@@ -110,8 +101,6 @@ describe('Scheduler', () => {
         const group1 = Symbol();
         const schedule = create();
 
-        createTag(schedule, group1);
-
         add(schedule, aFn, tag(group1), id('A'));
         add(schedule, bFn, after('A'), tag(group1), id('B'));
 
@@ -126,8 +115,6 @@ describe('Scheduler', () => {
     test('schedule a runnable before and after a tag', () => {
         const group1 = Symbol();
         const schedule = create();
-
-        createTag(schedule, group1);
 
         add(schedule, aFn, tag(group1), id('A'));
         add(schedule, bFn, after('A'), tag(group1), id('B'));
@@ -147,8 +134,6 @@ describe('Scheduler', () => {
     test('schedule a runnable into an existing tag', () => {
         const group1 = Symbol();
         const schedule = create();
-
-        createTag(schedule, group1);
 
         add(schedule, aFn, id('A'), tag(group1), id('A'));
         add(schedule, bFn, after('A'), tag(group1), id('B'));
@@ -194,13 +179,9 @@ describe('Scheduler', () => {
 
         const schedule = create();
 
-        createTag(schedule, group1);
-        createTag(schedule, group2, before(group1));
-        createTag(schedule, group3, after(group1));
-
         add(schedule, aFn, tag(group1), id('A'));
-        add(schedule, bFn, tag(group2), id('B'));
-        add(schedule, cFn, tag(group3), id('C'));
+        add(schedule, bFn, tag(group2), id('B'), before(group1));
+        add(schedule, cFn, tag(group3), id('C'), after(group1));
 
         run(schedule, {});
 
@@ -211,17 +192,20 @@ describe('Scheduler', () => {
         expect(order).toEqual(['B', 'A', 'C']);
     });
 
-    test.fails('scheduling the same runnable multiple times does not run it multiple times', () => {
-        const schedule = create();
+    test.fails(
+        'scheduling the same runnable multiple times does not run it multiple times',
+        () => {
+            const schedule = create();
 
-        add(schedule, aFn, id('A'));
-        add(schedule, aFn, id('A'));
-        add(schedule, aFn, id('A'));
+            add(schedule, aFn, id('A'));
+            add(schedule, aFn, id('A'));
+            add(schedule, aFn, id('A'));
 
-        run(schedule, {});
+            run(schedule, {});
 
-        expect(aFn).toBeCalledTimes(1);
+            expect(aFn).toBeCalledTimes(1);
 
-        expect(order).toEqual(['A']);
-    });
+            expect(order).toEqual(['A']);
+        }
+    );
 });


### PR DESCRIPTION
This is a simple PR that creates a tag if it is not found instead of erroring, making `createTag` unnecessary to call. This reduces the boilerplate on all the tag tests in alignment with how I expect to use it.

```js
test('schedule a runnable with tag', () => {
    const group1 = Symbol();
    const schedule = create();

    // This call is no longer necessary
    // createTag(schedule, group1);

    add(schedule, aFn, tag(group1), id('A'));
    add(schedule, bFn, after('A'), tag(group1), id('B'));

    run(schedule, {});

    expect(aFn).toBeCalledTimes(1);
    expect(bFn).toBeCalledTimes(1);

    expect(order).toEqual(['A', 'B']);
});
  ```

Similarly, scheduling tags with each other no longer becomes necessary. It can be inherited, for lack of a better word, from scheduling the runnable itself.

```js
// This boilerplate becomes...
test('schedule a tag before or after another tag', () => {
    const group1 = Symbol();
    const group2 = Symbol();
    const group3 = Symbol();

    const schedule = create();

    createTag(schedule, group1);
    createTag(schedule, group2, before(group1));
    createTag(schedule, group3, after(group1));

    add(schedule, aFn, tag(group1), id('A'));
    add(schedule, bFn, tag(group2), id('B'));
    add(schedule, cFn, tag(group3), id('C'));

    run(schedule, {});

    expect(aFn).toBeCalledTimes(1);
    expect(bFn).toBeCalledTimes(1);
    expect(cFn).toBeCalledTimes(1);

    expect(order).toEqual(['B', 'A', 'C']);
});

// This
test('schedule a tag before or after another tag', () => {
    const group1 = Symbol();
    const group2 = Symbol();
    const group3 = Symbol();

    const schedule = create();

    add(schedule, aFn, tag(group1), id('A'));
    add(schedule, bFn, tag(group2), id('B'), before(group1));
    add(schedule, cFn, tag(group3), id('C'), after(group1));

    run(schedule, {});

    expect(aFn).toBeCalledTimes(1);
    expect(bFn).toBeCalledTimes(1);
    expect(cFn).toBeCalledTimes(1);

    expect(order).toEqual(['B', 'A', 'C']);
});
```
To determine would be how "inheriting" dependencies works for tags. We will need to come up with more complicated tests for this. The way I see it is that tags are empty until they get a runnable and runnables themselves have dependencies. The tag then is a way to describe a collection of runnables with "before" meaning "before the first tagged runnable in the sort" and "after" meaning "after the last tagged runnable in the sort".